### PR TITLE
fix：ポモドーロタイマーの完成.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,30 @@
 ## analog-pomodoro
+- [analog-pomodoro](https://k2webservice.xsrv.jp/r0105/analog-pomodoro/)
 
 ## 概要
-ポモドーロ：通知機能（サウンド）、アナログ時計、分度器のような（30分の）視覚ブロック
+アナログ時計なポモドーロタイマーです。半月状の（30分の）視覚画像で直感的に把握できます。タスク開始と休憩開始時に通知（サウンド）が鳴ります。
 
+### ポモドーロとは
 - その日に達成したい1つのタスクを細かく分割する
 1. 分割した1つのタスクを25分間集中して行う（タイマーをセット）
 2. 5分休憩を取る
 3. 1と2を繰り返し、4ポモドーロ（2時間）ごとに15〜30分間の休憩を取る
 
-## 通知音ソース
+## ビルド時の注意
+- `vite.config.ts`
+`base`部分を有効化してビルドする。
+
+```diff
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+// https://vite.dev/config/
+export default defineConfig({
+  plugins: [react()],
++  base: 'r0105/analog-pomodoro'
+})
+```
+
+## サウンドソース
 - [Level Up #3 | universfield](https://pixabay.com/ja/users/universfield-28281460/)
 - [Good! | Pixabay](https://pixabay.com/ja/users/pixabay-1/)

--- a/src/components/utils/Pomodoro.tsx
+++ b/src/components/utils/Pomodoro.tsx
@@ -12,14 +12,14 @@ export const Pomodoro = () => {
             {isPomodoroDone ?
                 <p>お疲れ様でした。<br />ポモドーロ終了です。15〜30分ほど休憩してください。</p> :
                 <>
-                    <h2>Pomodoro<br />（{isPause ? pomodoro + 1 : pomodoro}/4）</h2>
+                    <h2>Pomodoro<br />（{pomodoro}/4）</h2>
                     {isFocus && <p className="pomodoroFocus">ポモドーロ開始です。25分間タスクに集中してください。</p>}
                     {isBreak && <p className="pomodoroBreak">インターバルです。5分間休憩してください。</p>}
                 </>
             }
             {isBtnActive ?
                 <button className="pauseBtn" type="button" onClick={handlePause}>{isPause ? '中断' : '再開'}</button> :
-                <button type="button" onClick={() => handlePomodoro()}>ポモドーロ開始</button>
+                <button type="button" onClick={handlePomodoro}>ポモドーロ開始</button>
             }
             <audio id="startSound" src={startSound} hidden>&nbsp;</audio>
             <audio id="doneSound" src={doneSound} hidden>&nbsp;</audio>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,4 +4,5 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  // base: 'r0105/analog-pomodoro'
 })


### PR DESCRIPTION
- `src/components/hooks/useHandlePomodoro.ts`<br>余計な引数での値渡しをやめてシンプルな実装に変更（無駄に複雑な実装にしてしまっていた）
- `src/components/utils/Pomodoro.tsx`<br>上記のカスタムフックの修正に伴う調整