### PR TITLE
fix：linterのクリアと補足情報をREADMEに追記、秒の時針とデジタル時計の追加.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@
 - [Good! | Pixabay](https://pixabay.com/ja/users/pixabay-1/)
 
 ## 参考情報
-[【JavaScript】Safari だけじゃないオーディオ再生の制約と再生開始遅延の解決方法](https://webfrontend.ninja/js-audio-autoplay-policy-and-delay/)
+- [【JavaScript】Safari だけじゃないオーディオ再生の制約と再生開始遅延の解決方法](https://webfrontend.ninja/js-audio-autoplay-policy-and-delay/)
+- [ReactでcreateContextとuseContextを同一ファイル内でexportすると警告が出る](https://iwb.jp/react-createcontext-usecontext-file-export-warning/#google_vignette)
 
 ## 備忘録
 

--- a/src/components/Clock.tsx
+++ b/src/components/Clock.tsx
@@ -4,11 +4,12 @@ import { SelectTerm } from "./utils/SelectTerm";
 import { Pomodoro } from "./utils/Pomodoro";
 import { ClockHands } from "./utils/ClockHands";
 import { ThePie } from "./utils/ThePie";
+import { DigitalClock } from "./DigitalClock";
 import { useCurrTimeCalc } from "./hooks/useCurrTimeCalc";
 
 export const Clock = () => {
   const theClockRef = useRef<HTMLDivElement | null>(null);
-  const { currTimeCalc } = useCurrTimeCalc();
+  const { currTimeCalc, currTime } = useCurrTimeCalc();
 
   useEffect(() => {
     const theInterval: number = currTimeCalc(theClockRef);
@@ -18,6 +19,7 @@ export const Clock = () => {
       clearInterval(theInterval);
       clearTimeout(theTimeout);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (
@@ -25,11 +27,12 @@ export const Clock = () => {
       <SelectTerm />
       <Pomodoro />
       <TheClock ref={theClockRef} className="clock">
-        <div id="long">&nbsp;</div>
-        <div id="short">&nbsp;</div>
-        <div id="sec">&nbsp;</div>
+        <div className="theClockPart" id="long">&nbsp;</div>
+        <div className="theClockPart" id="short">&nbsp;</div>
+        <div className="theClockPart" id="sec">&nbsp;</div>
         <ClockHands />
         <div className="pomodoroImg"><ThePie /></div>
+        <DigitalClock currTime={currTime} />
       </TheClock>
     </>
   );
@@ -52,7 +55,7 @@ z-index: 0;
     top: 50%;
     left: 50%;
     transform-origin: left top;
-    transform: translate(-50%, -50%);
+    transform: translate(0%, -50%);
     transition: rotate .5s;
     visibility: hidden;
     z-index: -1;
@@ -75,7 +78,7 @@ z-index: 0;
     z-index: 2;
   }
   
-  & div {
+  & .theClockPart {
     border-radius: 16px;
     transform-origin: center left;
     position: absolute;
@@ -114,7 +117,7 @@ width: 400px;
 height: 400px;
 filter: drop-shadow(0px 0px 4px rgba(0, 0, 0, .25));
 
-  & div {
+  & .theClockPart {
     &#long {
       width: 180px;
       height: 3px;

--- a/src/components/DigitalClock.tsx
+++ b/src/components/DigitalClock.tsx
@@ -1,0 +1,25 @@
+import styled from "styled-components";
+
+export const DigitalClock = ({ currTime }: { currTime: string }) => {
+    return <TheDigitalClock>{currTime}</TheDigitalClock>;
+}
+
+const TheDigitalClock = styled.section`
+position: absolute;
+margin: auto;
+inset: 0;
+transform: translate(0%, 6em);
+width: fit-content;
+height: fit-content;
+padding: .25em 1em;
+color: #818181;
+border: 3px solid #818181;
+border-radius: .4rem;
+font-size: calc(100vw/40);
+font-feature-settings: "palt";
+
+@media screen and (min-width: 560px) {
+    font-size: 16px;
+    border-radius: 4px;
+}
+`;

--- a/src/components/hooks/useCurrTimeCalc.ts
+++ b/src/components/hooks/useCurrTimeCalc.ts
@@ -1,13 +1,57 @@
+import { useState } from "react";
+
 export const useCurrTimeCalc = () => {
+    type japDay = "日" | "月" | "火" | "水" | "木" | "金" | "土" | undefined;
+    const _getJapDay: (currDay: number) => japDay = (currDay: number) => {
+        switch (currDay) {
+            case 0:
+                return '日';
+            case 1:
+                return '月';
+            case 2:
+                return '火';
+            case 3:
+                return '水';
+            case 4:
+                return '木';
+            case 5:
+                return '金';
+            case 6:
+                return '土';
+            default:
+                return undefined;
+        }
+    }
+
+    const [currTime, setCurrTime] = useState<string>('');
+    const _checkCurrTime: (theDate: Date) => void = (theDate: Date) => {
+        const currMonth: number = theDate.getMonth() + 1;
+        const currDayDate: number = theDate.getDate();
+        const currDay: number = theDate.getDay();
+        const adjustCurrDay: japDay | null = typeof _getJapDay(currDay) !== 'undefined' ? _getJapDay(currDay) : null;
+
+        const currHours: string = theDate.getHours().toString().padStart(2, '0');
+        const currMinutes: string = theDate.getMinutes().toString().padStart(2, '0');
+        const currSeconds: string = theDate.getSeconds().toString().padStart(2, '0');
+
+        // mm月dd日（d）hh：mm：ss
+        const thePresent: string = `${currMonth}月${currDayDate}日（${adjustCurrDay}）${currHours}：${currMinutes}：${currSeconds}`;
+
+        setCurrTime(thePresent);
+    }
+
     const currTimeCalc: (theClock: React.MutableRefObject<HTMLDivElement | null>) => number = (theClock: React.MutableRefObject<HTMLDivElement | null>) => {
         const hours: Element | null | undefined = theClock.current?.querySelector('#short');
         const minutes: Element | null | undefined = theClock.current?.querySelector('#long');
         const seconds: Element | null | undefined = theClock.current?.querySelector('#sec');
 
         const theInterval: number = setInterval(() => {
-            const currHours: number = new Date().getHours();
-            const currMinutes: number = new Date().getMinutes();
-            const currSeconds: number = new Date().getSeconds();
+            const theDate: Date = new Date();
+            _checkCurrTime(theDate);
+
+            const currHours: number = theDate.getHours();
+            const currMinutes: number = theDate.getMinutes();
+            const currSeconds: number = theDate.getSeconds();
 
             const targetHoursDeg: number = Math.floor((currHours * 30) + (currMinutes * 0.5)); // 360/12（30度ずつ進む）
             const targetMinutesDeg: number = Math.floor(currMinutes * 6); // 360/60（6度ずつ進む）
@@ -30,5 +74,5 @@ export const useCurrTimeCalc = () => {
         return theInterval;
     }
 
-    return { currTimeCalc }
+    return { currTimeCalc, currTime }
 }

--- a/src/components/hooks/useHandlePomodoro.ts
+++ b/src/components/hooks/useHandlePomodoro.ts
@@ -43,18 +43,23 @@ export const useHandlePomodoro: handlePomodoroType = () => {
         setPomodoroStart(false);
         clearInterval(theInterval);
         pomodoroCounter = 1;
-        setPomodoro((_prevPomodoro) => 1);
-        setIntervalValue((_prevIntervalValue) => null);
+        setPomodoro(1);
+        setIntervalValue(null);
         setBtnActive(false);
     }
 
     /* ポモドーロの一時停止及び当該ポモドーロの再スタートに関する処理 */
     const handlePause: () => void = () => {
-        isFocus && setFocus(false);
-        isBreak && setBreak(false);
+        if (isFocus) {
+            setFocus(false);
+        }
+
+        if (isBreak) {
+            setBreak(false);
+        }
 
         if (isPause) {
-            setPomodoro((_prevPomodoro) => pomodoro);
+            setPomodoro(pomodoro);
             alert('ポモドーロが中断されました');
             if (intervalValue !== null) {
                 clearInterval(intervalValue);
@@ -62,6 +67,7 @@ export const useHandlePomodoro: handlePomodoroType = () => {
         } else {
             handlePomodoro();
         }
+
         // セッター関数は再レンダリングのトリガーなので、初期表示時は（初期設定時の）true のフローに進み、次レンダリング時には false のフローへ進む
         setPause(!isPause);
     }
@@ -104,7 +110,7 @@ export const useHandlePomodoro: handlePomodoroType = () => {
 
             else if (isReStartTerm) {
                 pomodoroCounter++;
-                setPomodoro((_prevPomodoro) => pomodoroCounter);
+                setPomodoro(pomodoroCounter);
                 _beginPomodoroImgEffect();
                 _ctrlPomodoroSignal();
                 clearInterval(theInterval);
@@ -115,7 +121,7 @@ export const useHandlePomodoro: handlePomodoroType = () => {
             }
         }, 1000);
 
-        setIntervalValue((_prevIntervalValue) => theInterval);
+        setIntervalValue(theInterval);
     }
 
     const handlePomodoro: () => void = () => {

--- a/src/components/utils/ClockHands.tsx
+++ b/src/components/utils/ClockHands.tsx
@@ -1,43 +1,81 @@
 import styled from "styled-components";
 import { useState } from "react";
 
-export const ClockHands = () => {
-    const ClockHandsAry: string[] = [];
-    for (let i = 1; i <= 12; i++) {
-        ClockHandsAry.push(`${30 * i}deg`);
-    }
-    const [theClockHandsAry] = useState<string[]>(ClockHandsAry);
-
+const TimeBullet = ({ targetTimeAry }: { targetTimeAry: string[] }) => {
     return (
         <>
-            {
-                theClockHandsAry.length > 0 &&
-                <TheClockHands>
-                    {theClockHandsAry.map(clockHandsElm => (
-                        <li key={clockHandsElm} style={{ 'rotate': `${clockHandsElm}` }}>&nbsp;</li>
-                    ))}
-                </TheClockHands>
-            }
+            {targetTimeAry.map(clockHand => (
+                <li key={clockHand} style={{ 'rotate': `${clockHand}` }}>&nbsp;</li>
+            ))}
         </>
+    )
+}
+
+export const ClockHands = () => {
+    /* 分の時針 */
+    const ClockHandsMinAry: string[] = [];
+    for (let i = 1; i <= 12; i++) {
+        ClockHandsMinAry.push(`${30 * i}deg`);
+    }
+    const [theClockHandsMinAry] = useState<string[]>(ClockHandsMinAry);
+
+    /* 秒の時針 */
+    const ClockHandsSecAry: string[] = [];
+    for (let i = 1; i <= 60; i++) {
+        ClockHandsSecAry.push(`${6 * i}deg`);
+    }
+    const [theClockHandsSecAry] = useState<string[]>(ClockHandsSecAry);
+
+    return (
+        <TheClockHands>
+            {theClockHandsMinAry.length > 0 &&
+                <ul>
+                    <TimeBullet targetTimeAry={theClockHandsMinAry} />
+                </ul>
+            }
+            {theClockHandsSecAry.length > 0 &&
+                <ul className="secClockHand">
+                    <TimeBullet targetTimeAry={theClockHandsSecAry} />
+                </ul>
+            }
+        </TheClockHands>
     );
 }
 
-const TheClockHands = styled.ul`
-list-style: none;
+const TheClockHands = styled.div`
+& ul {
+    list-style: none;
 
-& li {
-  width: 2.5em;
-  height: 1px;
-  position: absolute;
-  margin: auto;
-  inset: 0;
-  background-color: #333;
-  transform: translateX(calc(100vw/3));
+    & li {
+        width: 2.5em;
+        height: 1px;
+        position: absolute;
+        margin: auto;
+        inset: 0;
+        background-color: #333;
+        transform: translateX(calc(100vw/3));
+    }
+}
+
+& .secClockHand {
+    & li {
+        transform: translateX(calc(100vw/2.8));
+        background-color: #818181;
+        mix-blend-mode: darken;
+    }
 }
 
 @media screen and (min-width: 560px) {
-    & li {
-        transform: translateX(14em);
+    & ul {
+        & li {
+            transform: translateX(14em);
+        }
+    }
+
+    & .secClockHand {
+        & li {
+            transform: translateX(15em);
+        }
     }
 }
 `;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,9 +1,9 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
-import { PomodoroStartContextFragment } from './providers/PomodoroStartContext.tsx'
-import { PomodoroTimeContextFragment } from './providers/PomodoroTimeContext.tsx'
 import App from './App.tsx'
+import { PomodoroStartContextFragment } from './providers/PomodoroStartContextProvider.tsx'
+import { PomodoroTimeContextFragment } from './providers/PomodoroTimeContextProvider.tsx'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/src/providers/PomodoroStartContext.tsx
+++ b/src/providers/PomodoroStartContext.tsx
@@ -1,19 +1,7 @@
-import { createContext, ReactNode, useState } from "react";
+import { createContext } from "react";
 
 type Default = {
     pomodoroStart: boolean;
     setPomodoroStart: React.Dispatch<React.SetStateAction<boolean>>;
 }
 export const PomodoroStartContext = createContext({} as Default);
-
-export const PomodoroStartContextFragment = ({ children }: { children: ReactNode }) => {
-    const [pomodoroStart, setPomodoroStart] = useState<boolean>(false);
-
-    return (
-        <PomodoroStartContext.Provider value={{
-            pomodoroStart, setPomodoroStart
-        }}>
-            {children}
-        </PomodoroStartContext.Provider>
-    );
-}

--- a/src/providers/PomodoroStartContextProvider.tsx
+++ b/src/providers/PomodoroStartContextProvider.tsx
@@ -1,0 +1,14 @@
+import { ReactNode, useState } from "react";
+import { PomodoroStartContext } from "./PomodoroStartContext";
+
+export const PomodoroStartContextFragment = ({ children }: { children: ReactNode }) => {
+    const [pomodoroStart, setPomodoroStart] = useState<boolean>(false);
+
+    return (
+        <PomodoroStartContext.Provider value={{
+            pomodoroStart, setPomodoroStart
+        }}>
+            {children}
+        </PomodoroStartContext.Provider>
+    );
+}

--- a/src/providers/PomodoroTimeContext.tsx
+++ b/src/providers/PomodoroTimeContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, ReactNode, useState } from "react";
+import { createContext } from "react";
 import { setPomodoroTimeType } from "../components/utils/types/ThePomodoroTypes";
 
 type Default = {
@@ -6,20 +6,3 @@ type Default = {
     setPomodoroTime: React.Dispatch<React.SetStateAction<setPomodoroTimeType>>;
 }
 export const PomodoroTimeContext = createContext({} as Default);
-
-export const PomodoroTimeContextFragment = ({ children }: { children: ReactNode }) => {
-    // 180deg == 30m（6deg * 30）, 30deg == 5m（6deg * 5）
-    const initPomodoroTime: setPomodoroTimeType = {
-        focus_reStartTime: 150,
-        breakStartTime: 30
-    }
-    const [pomodoroTime, setPomodoroTime] = useState<setPomodoroTimeType>(initPomodoroTime);
-
-    return (
-        <PomodoroTimeContext.Provider value={{
-            pomodoroTime, setPomodoroTime
-        }}>
-            {children}
-        </PomodoroTimeContext.Provider>
-    );
-}

--- a/src/providers/PomodoroTimeContextProvider.tsx
+++ b/src/providers/PomodoroTimeContextProvider.tsx
@@ -1,0 +1,20 @@
+import { PomodoroTimeContext } from "./PomodoroTimeContext";
+import { ReactNode, useState } from "react";
+import { setPomodoroTimeType } from "../components/utils/types/ThePomodoroTypes";
+
+export const PomodoroTimeContextFragment = ({ children }: { children: ReactNode }) => {
+    // 180deg == 30m（6deg * 30）, 30deg == 5m（6deg * 5）
+    const initPomodoroTime: setPomodoroTimeType = {
+        focus_reStartTime: 150,
+        breakStartTime: 30
+    }
+    const [pomodoroTime, setPomodoroTime] = useState<setPomodoroTimeType>(initPomodoroTime);
+
+    return (
+        <PomodoroTimeContext.Provider value={{
+            pomodoroTime, setPomodoroTime
+        }}>
+            {children}
+        </PomodoroTimeContext.Provider>
+    );
+}


### PR DESCRIPTION
- linterのクリアと補足情報をREADMEに追記
  - `src/components/hooks/useHandlePomodoro.ts` <br>（`linter`チェックによる）`useState`関連の記述ミスを対応
  - `src/main.tsx`
    - **コンテキストとプロバイダーを分離しないと`linter`チェックでエラーが出る**ので、その対応を行った
    -  `src/providers`dir配下の各コンテキスト（グローバルステート）コンポーネント<br>コンテキストとプロバイダーの分離
  - `README.md`
- 秒の時針を追加
`src/components/utils/ClockHands.tsx`
- デジタル時計の追加
  - `src/components/DigitalClock.tsx`
  - `src/components/hooks/useCurrTimeCalc.ts`
  - デジタル時計の追加及び各種スタイルの調整
    - `src/components/Clock.tsx`