### PR TITLE
iOSでのポモドーロ開始時に時計周囲の分針がチラつく挙動への対応検証.

### DIFF
--- a/src/components/Clock.tsx
+++ b/src/components/Clock.tsx
@@ -61,6 +61,8 @@ z-index: 0;
     z-index: -1;
 
     & svg {
+      // will-changeでブラウザに変更予定を知らせる
+      will-change: transform;
       transform: scale(4);
     }
   }

--- a/src/components/utils/ClockHands.tsx
+++ b/src/components/utils/ClockHands.tsx
@@ -43,6 +43,10 @@ export const ClockHands = () => {
 }
 
 const TheClockHands = styled.div`
+width: 100%;
+height: 100%;
+overflow: hidden;
+
 & ul {
     list-style: none;
 


### PR DESCRIPTION
- iOSでのポモドーロ開始時に時計周囲の分針がチラつく挙動への対応検証
  - `src/components/Clock.tsx`<br>当該要素に、`will-change`でブラウザに変更予定を知らせる
  - `src/components/utils/ClockHands.tsx`<br>時計周囲の分針親要素のスタイルを調整