### PR TITLE
fix：iOSでの表示が著しく崩れたため再修正.

### DIFF
--- a/src/components/Clock.tsx
+++ b/src/components/Clock.tsx
@@ -61,8 +61,6 @@ z-index: 0;
     z-index: -1;
 
     & svg {
-      // will-changeでブラウザに変更予定を知らせる
-      will-change: transform;
       transform: scale(4);
     }
   }

--- a/src/components/utils/ClockHands.tsx
+++ b/src/components/utils/ClockHands.tsx
@@ -43,11 +43,10 @@ export const ClockHands = () => {
 }
 
 const TheClockHands = styled.div`
-width: 100%;
-height: 100%;
-overflow: hidden;
-
 & ul {
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
     list-style: none;
 
     & li {


### PR DESCRIPTION
- iOSでの表示が著しく崩れたため再修正
  - `src/components/Clock.tsx`<br>`will-change`は関係ないことが判明したので削除
  - `src/components/utils/ClockHands.tsx`<br>リスト（時計周囲の分針）の親（`ul`）のスタイルが関係していそう