### PR TITLE
fix：iOSのチラつき対策（重なり順と透過及び色味調整で対応）.

### DIFF
--- a/src/components/Clock.tsx
+++ b/src/components/Clock.tsx
@@ -58,7 +58,9 @@ z-index: 0;
     transform: translate(0%, -50%);
     transition: rotate .5s;
     visibility: hidden;
-    z-index: -1;
+    z-index: -1; // iOSでのチラつき対策：時計周囲の分針（z-index: -2）より前面に配置
+    opacity: .5; // 透過させて時計周囲の分針を視認できるようにする
+    filter: saturate(3); // 透過させた分の色味調整
 
     & svg {
       transform: scale(4);

--- a/src/components/utils/ClockHands.tsx
+++ b/src/components/utils/ClockHands.tsx
@@ -44,11 +44,8 @@ export const ClockHands = () => {
 
 const TheClockHands = styled.div`
 & ul {
-    width: 100%;
-    height: 100%;
-    overflow: hidden;
     list-style: none;
-
+    
     & li {
         width: 2.5em;
         height: 1px;
@@ -57,6 +54,7 @@ const TheClockHands = styled.div`
         inset: 0;
         background-color: #333;
         transform: translateX(calc(100vw/3));
+        z-index: -2;
     }
 }
 


### PR DESCRIPTION
- iOSのチラつき対策（重なり順と透過及び色味調整で対応）
  - `src/components/Clock.tsx`<br>ポモドーロ期間を表す視覚用画像の重なり順や透明度、色味を調整
  - `src/components/utils/ClockHands.tsx`<br>時計周囲の分針の重なり順を調整

これら処理によりチラつき（ポモドーロ開始時に親要素の`overflow:hidden`が効かなくなる）を防ぐことに成功